### PR TITLE
Fix memory leak and fix intermediary 16-bit saturate in accumulator

### DIFF
--- a/gemmini/gemmini.cc
+++ b/gemmini/gemmini.cc
@@ -425,9 +425,9 @@ void gemmini_t::compute(reg_t a_addr, reg_t bd_addr, bool preload) {
                   rounding_saturating_shift<output_t>(value, gemmini_state.sys_shift) :
                   rounding_saturating_shift<output_t>(value, 0);
           if (acc_accum) {
-            gemmini_state.accumulator.at(base_sp_addr + i).at(j) += shifted;
+            gemmini_state.accumulator.at(base_sp_addr + i).at(j) += value;
           } else { // Overwrite
-            gemmini_state.accumulator.at(base_sp_addr + i).at(j) = shifted;
+            gemmini_state.accumulator.at(base_sp_addr + i).at(j) = value;
           }
 #ifdef ELEM_T_IS_FLOAT
           dprintf("%f ", gemmini_state.accumulator.at(base_sp_addr + i).at(j));

--- a/gemmini/gemmini.h
+++ b/gemmini/gemmini.h
@@ -51,9 +51,9 @@ struct gemmini_state_t
   bool b_transpose;
 
   bool enable;
-  std::vector<std::vector<elem_t>> *spad; // Scratchpad constructed as systolic array rows
-  std::vector<std::vector<acc_t>> *pe_state; // Stores each PE's internal accumulator state
-  std::vector<std::vector<acc_t>> *accumulator;
+  std::vector<std::vector<elem_t>> spad; // Scratchpad constructed as systolic array rows
+  std::vector<std::vector<acc_t>> pe_state; // Stores each PE's internal accumulator state
+  std::vector<std::vector<acc_t>> accumulator;
 };
 
 class gemmini_t : public rocc_t


### PR DESCRIPTION
* `new vector<>` without corresponding `delete` caused OOM. Fix by just using `vector`
* The simulation has a 16-bit saturate before moving to the accumulator, which can lead to results different from actual since in hardware the saturation is done at a bitwidth sufficient to hold the intermediary.